### PR TITLE
Remove warnings due to using public overshadowing getters in sequelize.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/sinon": "^17.0.3",
         "@typescript-eslint/eslint-plugin": "~6.15",
         "@typescript-eslint/parser": "~6.15",
+        "cross-env": "^7.0.3",
         "eslint": "~8.56",
         "eslint-config-prettier": "~9.1",
         "mocha": "^10.3.0",
@@ -1122,6 +1123,24 @@
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "nodemon src/server.ts",
     "build": "tsc -p tsconfig.json",
     "lint": "eslint . --ext .ts --ext .mts",
-    "test": "mocha --require ts-node/register --timeout 10000  --recursive '__tests__/**/*.test.ts'"
+    "test": "cross-env NODE_ENV=test mocha --require ts-node/register --timeout 10000  --recursive '__tests__/**/*.test.ts'"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
@@ -21,6 +21,7 @@
     "@types/sinon": "^17.0.3",
     "@typescript-eslint/eslint-plugin": "~6.15",
     "@typescript-eslint/parser": "~6.15",
+    "cross-env": "^7.0.3",
     "eslint": "~8.56",
     "eslint-config-prettier": "~9.1",
     "mocha": "^10.3.0",

--- a/src/config/sequalizeConfig.ts
+++ b/src/config/sequalizeConfig.ts
@@ -1,4 +1,4 @@
-import { Sequelize } from 'sequelize';
+import { Dialect, Sequelize } from 'sequelize';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -10,14 +10,14 @@ if (!HOST || !DATABASE || !USER || !PASSWORD) {
     'Please provide values for HOST, DATABASE, USER, PASSWORD, and PORT in the .env file.',
   );
 }
-
-export const sequelize = new Sequelize({
-  dialect: 'mysql',
+console.log('Current Env', process.env.NODE_ENV);
+const prodConfig = {
+  dialect: 'mysql' as Dialect,
   host: HOST,
   database: DATABASE,
   username: USER,
   password: PASSWORD,
-
+  logging: process.env.NODE_ENV === 'test' ? false : console.log,
   // port: parseInt(PORT),
   // This is only for online DB's
   //   dialectOptions: {
@@ -27,6 +27,8 @@ export const sequelize = new Sequelize({
   //       ca: CA,
   //     },
   //   },
-});
+};
+
+export const sequelize = new Sequelize(prodConfig);
 
 export default sequelize;

--- a/src/services/cardServices/createNewCardService.ts
+++ b/src/services/cardServices/createNewCardService.ts
@@ -37,20 +37,23 @@ const createNewCardService = async (cardData: Cards) => {
       );
 
       const createdCardId = createCard.get('card_id');
-      console.log(`New card created: ${createCard.toJSON()}`);
 
       // Return the created card_id
       return {
         status: true,
         message: 'Card created successfully',
-        data:  {cardId:createdCardId} ,
+        data: { cardId: createdCardId },
       };
     } else {
-      return { status: false, message: 'Card creation failed', data: {error:Error} };
+      return {
+        status: false,
+        message: 'Card creation failed',
+        data: { error: Error },
+      };
     }
   } catch (error) {
     console.error(error);
-    return { status: false, message: error.message ,data:{}};
+    return { status: false, message: error.message, data: {} };
   }
 };
 

--- a/src/types/modelTypes/cards.ts
+++ b/src/types/modelTypes/cards.ts
@@ -1,39 +1,21 @@
 import { Model } from 'sequelize';
-interface CardType {
-  card_id: string;
-  card_name: string | null;
-  img_front_link: string | null;
-  img_back_link: string | null;
-  job_title: string | null;
-  email: string | null;
-  phone: string | null;
-  company_name: string | null;
-  company_website: string | null;
-  description: string | null;
-  contact_name: string | null;
-  parent_card_id: string | null;
-  user_id: string | null;
-  shared_or_not: number | null;
-  createdAt: Date | null;
-  modifiedAt: Date | null;
-}
-class Cards extends Model<CardType> {
-  card_id: string;
-  card_name: string | null;
-  img_front_link: string | null;
-  img_back_link: string | null;
-  job_title: string | null;
-  email: string | null;
-  phone: string | null;
-  company_name: string | null;
-  company_website: string | null;
-  description: string | null;
-  contact_name: string | null;
-  parent_card_id: string | null;
-  user_id: string | null;
-  shared_or_not: number | null;
-  createdAt: Date | null;
-  modifiedAt: Date | null;
+class Cards extends Model {
+  declare card_id: string;
+  declare card_name: string | null;
+  declare img_front_link: string | null;
+  declare img_back_link: string | null;
+  declare job_title: string | null;
+  declare email: string | null;
+  declare phone: string | null;
+  declare company_name: string | null;
+  declare company_website: string | null;
+  declare description: string | null;
+  declare contact_name: string | null;
+  declare parent_card_id: string | null;
+  declare user_id: string | null;
+  declare shared_or_not: number | null;
+  declare createdAt: Date | null;
+  declare modifiedAt: Date | null;
 }
 
 export default Cards;

--- a/src/types/modelTypes/sharedCards.ts
+++ b/src/types/modelTypes/sharedCards.ts
@@ -1,22 +1,13 @@
 import { Model } from 'sequelize';
-
-interface SharedCardType {
-  shared_card_id: string;
-  card_id: string;
-  user_id: string;
-  status: string;
-  createdAt: Date;
-  modifiedAt: Date;
-}
-export class SharedCards extends Model<SharedCardType> {
-  shared_card_id: string;
-  card_id: string;
-  user_id: string;
-  status: string;
-  createdAt: Date;
-  modifiedAt: Date;
-  Card: any;
-  UserTable: any;
+export class SharedCards extends Model {
+  declare shared_card_id: string;
+  declare card_id: string;
+  declare user_id: string;
+  declare status: string;
+  declare createdAt: Date;
+  declare modifiedAt: Date;
+  declare Card: any;
+  declare UserTable: any;
 }
 
 export default SharedCards;

--- a/src/types/modelTypes/userTable.ts
+++ b/src/types/modelTypes/userTable.ts
@@ -1,20 +1,11 @@
 import { Model } from 'sequelize';
-interface UserTableType {
-  user_id: string;
-  user_fullname: string | null;
-  user_email: string | null;
-  password_hash: string | null;
-  createdAt: Date | null;
-  modifiedAt: Date | null;
-}
-export class UserTable extends Model<UserTableType> {
-  password_hash: string | null;
-  user_id: string;
-  user_fullname: string | null;
-  user_email: string | null;
-  createdAt: Date | null;
-  modifiedAt: Date | null;
-  static user_id: any;
+export class UserTable extends Model {
+  declare password_hash: string | null;
+  declare user_id: string;
+  declare user_fullname: string | null;
+  declare user_email: string | null;
+  declare createdAt: Date | null;
+  declare modifiedAt: Date | null;
 }
 
 export default UserTable;


### PR DESCRIPTION
- Remove warnings due to using public overshadowing getters in sequelize
- prevent showing Sequelize queries for  successful test
- remove unnecessary console.log in createNewCardService